### PR TITLE
Correct 410 status code

### DIFF
--- a/api.html.md.erb
+++ b/api.html.md.erb
@@ -551,7 +551,7 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/se
 
 A response code of `200 OK` with a body of `{}` indicates that the resource was
 deleted.
-A response code of `410 Not Found` with a body of `{}` indicates to Cloud
+A response code of `410 Gone` with a body of `{}` indicates to Cloud
 Controller that the resource was not there in the first place, and is likely
 gone.
 _Any other_ response code indicates to Cloud Controller that the the binding
@@ -614,7 +614,7 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:id?service_id=
 
 A response code of `200 OK` with a body of `{}` indicates that the resource was
 deleted.
-A response code of `410 Not Found `with a body of `{}` indicates to Cloud
+A response code of `410 Gone` with a body of `{}` indicates to Cloud
 Controller that the resource was not there in the first place, and is likely
 gone.
 _Any other_ response code indicates to Cloud Controller that the the service


### PR DESCRIPTION
RFC 2616 [lists](http://tools.ietf.org/html/rfc2616#section-10.4.11) it as `Gone`. `Not Found` is used by another code, so the current docs are ambiguous and confusing to the reader.
