### PR TITLE
Notify users that we no longer support v1 service brokers

### DIFF
--- a/api-v1.html.md.erb
+++ b/api-v1.html.md.erb
@@ -5,9 +5,8 @@ title: Writing a v1 Cloud Foundry Service
 There are two versions of the Cloud Foundry Services API. This page documents
 v1.
 
-<strong>DEPRECATED:</strong> We recommend that all new service brokers be
-written against the <a href="api.html">version 2 API</a>. Support for v1 service
-brokers will be removed at the end of 2015.
+<strong>UPDATE:</strong> As of CC API [version 229, 2.47.0](https://apidocs.cloudfoundry.org/229/),
+we no longer support v1 service brokers.
 
 Writing a service involves writing a service broker that obeys the API contract
 between the Cloud Controller v2 (CC) and a v1 service broker.


### PR DESCRIPTION
We are removing support for v1 service brokers in CC API Version 229