### PR TITLE
Add property `route_service_recommend_https` description to docs

### DIFF
--- a/route-services.html.md.erb
+++ b/route-services.html.md.erb
@@ -26,15 +26,19 @@ Operators may have middleware components through which all requests to Cloud Fou
 A broker delivers a self-service user experience for developers and through an integration with the CF Router, only requests for routes that require transformation are proxied to the Route Service.
 
 ## <a id='enabling-route-services-in-cloudfoundry'></a>Enabling Route Services in Cloud Foundry ##
+To enable support for Route Services in a Cloud Foundry deployment, the operator must provide a passphrase used by GoRouter to encrypt a header that is sent with the request to the route service. This header is used by GoRouter to validate the request sent by the route service to the application route. The passphrase is configured in the cf-release manifest.
+```
+properties:
+ router:
+   route_services_secret: QgIp1D0LXRZhZOb+dSFoWw==
+```
 
-To enable support for Route Services in a Cloud Foundry deployment, the operator must provide a passphrase used by GoRouter to encrypt a header that is sent with the request to the route service. This header is used by GoRouter to validate the request sent by the route service to the application route.
-
-This property can be configured in the cf-release manifest:
+Route Service instances should send requests to the value of x-cf-forwarded-url, obeying the scheme. The scheme is https by default; for environments that don't support TLS termination, this property can be set to false.
 
 ```
 properties:
-  router:
-    route_services_secret: QgIp1D0LXRZhZOb+dSFoWw==
+ router:
+   route_services_recommend_https: true
 ```
 
 This secret should be randomly generated for your deployment. See the [GoRouter spec](https://github.com/cloudfoundry/cf-release/blob/master/jobs/gorouter/spec) in cf-release for more details.


### PR DESCRIPTION
This PR describes how the `route_service_recommend_https` value to be used by operator.

Regards
@shashwathi and @atulkc
Tracker Story: https://www.pivotaltracker.com/story/show/100982038
[#100982038]

Signed-off-by: Atul Kshirsagar <atul.kshirsagar@gmail.com>