### PR TITLE
Encourage a robust passphrase for route services secret

### DIFF
--- a/route-services.html.md.erb
+++ b/route-services.html.md.erb
@@ -27,11 +27,12 @@ A broker delivers a self-service user experience for developers and through an i
 
 ## <a id='enabling-route-services-in-cloudfoundry'></a>Enabling Route Services in Cloud Foundry ##
 To enable support for Route Services in a Cloud Foundry deployment, the operator must provide a passphrase used by GoRouter to encrypt a header that is sent with the request to the route service. This header is used by GoRouter to validate the request sent by the route service to the application route. The passphrase is configured in the cf-release manifest.
+The `route_services_secret` property should be a robust passphrase. See the [GoRouter spec](https://github.com/cloudfoundry/cf-release/blob/master/jobs/gorouter/spec) in cf-release for more details.
 
 ```
 properties:
  router:
-   route_services_secret: QgIp1D0LXRZhZOb+dSFoWw==
+   route_services_secret: My Secret Passphase
 ```
 
 Route Service instances should send requests to the value of x-cf-forwarded-url, obeying the scheme. The scheme is https by default; for environments that don't support TLS termination, this property can be set to false.
@@ -41,8 +42,6 @@ properties:
  router:
    route_services_recommend_https: true
 ```
-
-This secret should be randomly generated for your deployment. See the [GoRouter spec](https://github.com/cloudfoundry/cf-release/blob/master/jobs/gorouter/spec) in cf-release for more details.
 
 The CF router will only forward requests to Route Services over SSL. By default, certificates provided by Route Services must be signed by a trusted CA. If they are not, the CF router will reject the request. In development environments this concern may be unreasonable. To disable SSL cert validation, modify the following property:
 


### PR DESCRIPTION
This PR updates the Route Services documentation to encourage users to provide a robust passphrase for the `route_services_secret` property.

@leochu and @shashwathi