### PR TITLE
Replace the tab with spaces

### DIFF
--- a/access-control.html.md.erb
+++ b/access-control.html.md.erb
@@ -64,9 +64,9 @@ USAGE:
    cf service-access [-b BROKER] [-e SERVICE] [-o ORG]
 
 OPTIONS:
-   -b 	access for plans of a particular broker
-   -e 	access for plans of a particular service offering
-   -o 	plans accessible by a particular organization
+   -b     access for plans of a particular broker
+   -e     access for plans of a particular service offering
+   -o     plans accessible by a particular organization
 </pre>
 
 ### <a id='enable-access'></a>Enable Access to Service Plans ###
@@ -103,8 +103,8 @@ USAGE:
    cf enable-service-access SERVICE [-p PLAN] [-o ORG]
 
 OPTIONS:
-   -p 	Enable access to a particular service plan
-   -o 	Enable access to a particular organization
+   -p     Enable access to a particular service plan
+   -o     Enable access to a particular organization
 </pre>
 
 ### <a id='disable-access'></a>Disable Access to Service Plans ###
@@ -137,8 +137,8 @@ USAGE:
    cf disable-service-access SERVICE [-p PLAN] [-o ORG]
 
 OPTIONS:
-   -p 	Disable access to a particular service plan
-   -o 	Disable access to a particular organization
+   -p     Disable access to a particular service plan
+   -o     Disable access to a particular organization
 </pre>
 
 #### Limitations ####

--- a/api-v1.html.md.erb
+++ b/api-v1.html.md.erb
@@ -92,7 +92,7 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>label*</td>
   <td>string</td>
   <td>The type of service offered, like "mongodb".
-	This must match the name of the service used for the service-auth-token</td>
+    This must match the name of the service used for the service-auth-token</td>
 </tr>
 <tr>
   <td>provider*</td>
@@ -113,14 +113,14 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>version*</td>
   <td>string</td>
   <td>The version string of the service provided to be displayed to users, 5.5
-	for mysql "5.5".
-	Multiple of the same services can exist with different versions.</td>
+    for mysql "5.5".
+    Multiple of the same services can exist with different versions.</td>
 </tr>
 <tr>
   <td>info_url</td>
   <td>string</td>
   <td>(Currently unused) A URL that users can visit to determine more
-	information about a service offering</td>
+    information about a service offering</td>
 </tr>
 <tr>
   <td>acls</td>
@@ -131,13 +131,13 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>timeout</td>
   <td>integer</td>
   <td>(Currently unused) How long the Cloud Controller should wait for a broker
-	to finish an operation before giving up.</td>
+    to finish an operation before giving up.</td>
 </tr>
 <tr>
   <td>active</td>
   <td>bool</td>
   <td>Used as a hint to CF front-ends that a service is not active and can no
-	longer be provisioned (not enforced by the Cloud Controller)</td>
+    longer be provisioned (not enforced by the Cloud Controller)</td>
 </tr>
 <tr>
   <td>extra</td>
@@ -148,30 +148,30 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>unique_id</td>
   <td>string</td>
   <td>A new identifier that must be globally unique.
-	This ID will be passed to the service broker as part of provision, bind,
-	etc. requests.
-	This "primary key" is easier to work with than the combination of
-	<code>[label, provider, version]</code> which also forms a "primary
-	key".</td>
+    This ID will be passed to the service broker as part of provision, bind,
+    etc. requests.
+    This "primary key" is easier to work with than the combination of
+    <code>[label, provider, version]</code> which also forms a "primary
+    key".</td>
 </tr>
 <tr>
   <td>bindable</td>
   <td>bool</td>
   <td>If false, cloud controller will return an error to frontend clients when a
-	user requests to bind an app to an instance of the service.</td>
+    user requests to bind an app to an instance of the service.</td>
 </tr>
 <tr>
   <td>tags</td>
   <td>array of objects</td>
   <td>Used by buildpacks and application libraries to parse credentials from the
-	VCAP_SERVICES environment variable.
-	Could also be used by frontend clients to filter marketplace services.</td>
+    VCAP_SERVICES environment variable.
+    Could also be used by frontend clients to filter marketplace services.</td>
 </tr>
 <tr>
   <td>documentation_url</td>
   <td>string</td>
   <td>(Currently unused) Used by frontend clients to display a URL to
-	documentation for the service.</td>
+    documentation for the service.</td>
 </tr>
 <tr>
   <td>service_plans</td>
@@ -194,7 +194,7 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>metadata</td>
   <td>object</td>
   <td>Contains guid and the Cloud Controller URL for manipulating the newly
-	created resource</td>
+    created resource</td>
 </tr>
 <tr>
   <td>entity</td>
@@ -245,7 +245,7 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>400</td>
   <td>Bad request</td>
   <td>one of: already defined, bad request, invalid params, missing field (error
-	message in the Cloud Controller log will have details as to why)</td>
+    message in the Cloud Controller log will have details as to why)</td>
 </tr>
 <tr>
   <td>401/403</td>
@@ -277,7 +277,7 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>collection-method</td>
   <td>add<br/>replace</td>
   <td>Merge any supplied plans with existing plans<br/>Replace existing plans
-	with supplied plans </td>
+    with supplied plans </td>
 </tr>
 </tbody>
 </table>
@@ -295,11 +295,11 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>label*<br/>provider*</br>version*</td>
   <td>string</td>
   <td>If `unique_id` is not provided, used to find the existing service to be
-	updated</td>
+    updated</td>
 </tr>
 <tr>
   <td colspan="3"><em>Everything else same as create endpoint, except
-	`unique_id` cannot be included</em></td>
+    `unique_id` cannot be included</em></td>
 </tr>
 </tbody>
 </table>
@@ -336,7 +336,7 @@ Generator](http://www.guidgenerator.com/ "Online GUID Generator").
   <td>inline-relation-depth</td>
   <td>0-3</td>
   <td>Set to 1 to get plans as well<br/>Set to 2 to get plans &
-	instances<br/>Set to 3 to get plans & instances & bindings</td>
+    instances<br/>Set to 3 to get plans & instances & bindings</td>
 </tr>
 <tr>
   <td>q</td>
@@ -403,7 +403,7 @@ attached to this service, as they must be deleted first.
   <td>free*</td>
   <td>bool</td>
   <td>Displayed by frontends, used by quota_definitions to determine whether an
-	org can provision a service</td>
+    org can provision a service</td>
 </tr>
 <tr>
   <td>description*</td>
@@ -419,16 +419,16 @@ attached to this service, as they must be deleted first.
   <td>unique_id</td>
   <td>string</td>
   <td>A new identifier that must be unique.
-	This ID will be passed as part of provision, bind, etc. requests.
-	This "primary key" is easier to work with than the combination of [label,
-	provider, version] which also forms a "primary key".</td>
+    This ID will be passed as part of provision, bind, etc. requests.
+    This "primary key" is easier to work with than the combination of [label,
+    provider, version] which also forms a "primary key".</td>
 </tr>
 <tr>
   <td>public</td>
   <td>bool</td>
   <td>Whether a plan should be automatically visible for all users.
-	When false, the rules behind service_plan_visibilities are used to decide
-	visibility.</td>
+    When false, the rules behind service_plan_visibilities are used to decide
+    visibility.</td>
 </tr>
 <tr>
   <td>service_guid*</td>
@@ -451,7 +451,7 @@ attached to this service, as they must be deleted first.
   <td>metadata</td>
   <td>object</td>
   <td>Contains guid and the Cloud Controller URL for manipulating the newly
-	created resource</td>
+    created resource</td>
 </tr>
 <tr>
   <td>entity</td>
@@ -495,7 +495,7 @@ attached to this service, as they must be deleted first.
   <td>inline-relation-depth</td>
   <td>0-2</td>
   <td>Set to 1 to get instances & spaces & service as well<br/>Set to 2 to get
-	service & instances & spaces & bindings
+    service & instances & spaces & bindings
 </tr>
 <tr>
   <td>q</td>
@@ -549,11 +549,11 @@ service
   <td>service_guid*<br/>name*
   <td>string</td>
   <td>If `unique_id` is not provided, used to find the existing plan to be
-	updated</td>
+    updated</td>
 </tr>
 <tr>
   <td colspan="3"><em>Everything else same as create endpoint, except
-	`unique_id` cannot be provided</em></td>
+    `unique_id` cannot be provided</em></td>
 </tr>
 </tbody>
 </table>
@@ -606,7 +606,7 @@ path below.
   <td>unique_id*</td>
   <td>string</td>
   <td>The unique_id of the desired <strong>service_plan</strong> to be
-	provisioned</td>
+    provisioned</td>
 </tr>
 <tr>
   <td>name*</td>
@@ -622,13 +622,13 @@ path below.
   <td>provider</td>
   <td>string</td>
   <td>The provider of the service to provision, in case the broker is
-	responsible for multiple services</td>
+    responsible for multiple services</td>
 </tr>
 <tr>
   <td>label</td>
   <td>string</td>
   <td>The label of the service to provision, in case the broker is responsible
-	for multiple services</td>
+    for multiple services</td>
 </tr>
 <tr>
   <td>plan</td>
@@ -639,19 +639,19 @@ path below.
   <td>version</td>
   <td>string</td>
   <td>The version of the service to provision, in case the broker is responsible
-	for multiple versions</td>
+    for multiple versions</td>
 </tr>
 <tr>
   <td>organization_guid</td>
   <td>string</td>
   <td>The GUID of the organization under which the service will be provisioned
-	(try not to use this)</td>
+    (try not to use this)</td>
 </tr>
 <tr>
   <td>space_guid</td>
   <td>string</td>
   <td>The GUID of the space under which the service will be provisioned (try not
-	to use this)</td>
+    to use this)</td>
 </tr>
 <tr>
   <td>plan_option</td>
@@ -680,25 +680,25 @@ Asterisks denote required fields.
   <td>service_id*</td>
   <td>string</td>
   <td>A broker-generated identifier that represents the resource, and will be
-	passed to the broker for future bind/deprovision requests</td>
+    passed to the broker for future bind/deprovision requests</td>
 </tr>
 <tr>
   <td>configuration*</td>
   <td>object</td>
   <td>The configuration used to provision this service, usually a copy of the
-	request attributes</td>
+    request attributes</td>
 </tr>
 <tr>
   <td>credentials*</td>
   <td>object</td>
   <td>Any credentials that were generated as a result of provisioning, that the
-	broker would like to be stored in the Cloud Controller.</td>
+    broker would like to be stored in the Cloud Controller.</td>
 </tr>
 <tr>
   <td>dashboard_url</td>
   <td>string</td>
   <td>If applicable, the URL that an end-user can visit to monitor/manage the
-	provisioned instances</td>
+    provisioned instances</td>
 </tr>
 </tbody>
 </table>
@@ -741,7 +741,7 @@ For legacy reasons, a binding is known as a "handle" on the broker side.
   <td>service_id*</td>
   <td>string</td>
   <td>The broker-generated identifier that identifies the instance to be
-	bound</td>
+    bound</td>
 </tr>
 <tr>
   <td>label*</td>
@@ -759,9 +759,9 @@ For legacy reasons, a binding is known as a "handle" on the broker side.
   <td>app_id</td>
   <td>string</td>
   <td>The identifier of the application that will receive the binding
-	credentials.<br/>
+    credentials.<br/>
   <em>Included in the cloud controller in commit f577e8444 on 12/3/2013 (it will
-	be included in cf-release v15X)</em>
+    be included in cf-release v15X)</em>
   </td>
 </tr>
 <tr>
@@ -791,21 +791,21 @@ Asterisks denote required fields.
   <td>service_id*</td>
   <td>string</td>
   <td>An identifier that’s generated by the broker and will be passed to the
-	broker for future unbind requests, it’s really a "handle_id" not a
-	service_id.</td>
+    broker for future unbind requests, it’s really a "handle_id" not a
+    service_id.</td>
 </tr>
 <tr>
   <td>configuration*</td>
   <td>object</td>
   <td>The configuration used to provision this service, usually a copy of the
-	request attributes</td>
+    request attributes</td>
 </tr>
 <tr>
   <td>credentials*</td>
   <td>object</td>
   <td>The credentials that were generated as part of this binding.
-	These credentials will be passed to the bound application as part of the
-	VCAP_SERVICES environment variable.</td>
+    These credentials will be passed to the bound application as part of the
+    VCAP_SERVICES environment variable.</td>
 </tr>
 </tbody>
 </table>
@@ -841,13 +841,13 @@ table:
   <td>service_id*</td>
   <td>string</td>
   <td>The broker service_id that was returned from the
-	<strong>provision</strong> response</td>
+    <strong>provision</strong> response</td>
 </tr>
 <tr>
   <td>handle_id*</td>
   <td>string</td>
   <td>The broker service_id that was returned from the <strong>binding</strong>
-	response</td>
+    response</td>
 </tr>
 <tr>
   <td>binding_options</td>

--- a/api-v2.0.html.md.erb
+++ b/api-v2.0.html.md.erb
@@ -410,16 +410,16 @@ Responses with any other status code will be interpreted as a failure and an unb
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.1.html.md.erb
+++ b/api-v2.1.html.md.erb
@@ -513,16 +513,16 @@ For success responses, the following fields are valid.
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.2.html.md.erb
+++ b/api-v2.2.html.md.erb
@@ -520,16 +520,16 @@ For success responses, the following fields are valid.
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.3.html.md.erb
+++ b/api-v2.3.html.md.erb
@@ -547,16 +547,16 @@ For success responses, the following fields are valid.
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.4.html.md.erb
+++ b/api-v2.4.html.md.erb
@@ -197,9 +197,9 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
   <td>&nbsp;&nbsp;&nbsp;plan_updateable</td>
   <td>boolean</td>
   <td>
-	  Whether the service supports upgrade/downgrade for some plans.
-	  <br/>
-	  Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
+      Whether the service supports upgrade/downgrade for some plans.
+      <br/>
+      Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
   </td>
 </tr>
 <tr>
@@ -666,16 +666,16 @@ For success responses, the following fields are supported. Others will be ignore
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.5.html.md.erb
+++ b/api-v2.5.html.md.erb
@@ -197,9 +197,9 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
   <td>&nbsp;&nbsp;&nbsp;plan_updateable</td>
   <td>boolean</td>
   <td>
-	  Whether the service supports upgrade/downgrade for some plans.
-	  <br/>
-	  Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
+      Whether the service supports upgrade/downgrade for some plans.
+      <br/>
+      Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
   </td>
 </tr>
 <tr>
@@ -711,16 +711,16 @@ For success responses, the following fields are supported. Others will be ignore
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.6.html.md.erb
+++ b/api-v2.6.html.md.erb
@@ -198,9 +198,9 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
   <td>&nbsp;&nbsp;&nbsp;plan_updateable</td>
   <td>boolean</td>
   <td>
-	  Whether the service supports upgrade/downgrade for some plans.
-	  <br/>
-	  Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
+      Whether the service supports upgrade/downgrade for some plans.
+      <br/>
+      Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
   </td>
 </tr>
 <tr>
@@ -723,16 +723,16 @@ For success responses, the following fields are supported. Others will be ignore
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.7.html.md.erb
+++ b/api-v2.7.html.md.erb
@@ -198,9 +198,9 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
   <td>&nbsp;&nbsp;&nbsp;plan_updateable</td>
   <td>boolean</td>
   <td>
-	  Whether the service supports upgrade/downgrade for some plans.
-	  <br/>
-	  Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
+      Whether the service supports upgrade/downgrade for some plans.
+      <br/>
+      Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
   </td>
 </tr>
 <tr>
@@ -866,16 +866,16 @@ For success responses, the following fields are supported. Others will be ignore
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.8.html.md.erb
+++ b/api-v2.8.html.md.erb
@@ -199,9 +199,9 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
   <td>&nbsp;&nbsp;&nbsp;plan_updateable</td>
   <td>boolean</td>
   <td>
-	  Whether the service supports upgrade/downgrade for some plans.
-	  <br/>
-	  Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
+      Whether the service supports upgrade/downgrade for some plans.
+      <br/>
+      Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
   </td>
 </tr>
 <tr>
@@ -921,16 +921,16 @@ For success responses, the following fields are supported. Others will be ignore
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/api-v2.9.html.md.erb
+++ b/api-v2.9.html.md.erb
@@ -1090,16 +1090,16 @@ For success responses, the following fields are supported. Others will be ignore
 </table>
 
 <pre class="terminal">
-	{
-	  "credentials": {
-	    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-	    "username": "mysqluser",
-	    "password": "pass",
-	    "host": "mysqlhost",
-	    "port": 3306,
-	    "database": "dbname"
-	  }
-	}
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
 </pre>
 
 ## <a id='unbinding'></a>Unbinding ##

--- a/binding-credentials.html.md.erb
+++ b/binding-credentials.html.md.erb
@@ -102,7 +102,7 @@ VCAP_SERVICES=
       plan: "20mb",
       credentials: {
         port: "6379",
-		host: "pub-redis-6379.us-east-1-2.3.ec2.redislabs.com",
+        host: "pub-redis-6379.us-east-1-2.3.ec2.redislabs.com",
         password: "1M5zd3QfWi9nUyya"
       }
     },

--- a/catalog-metadata.html.md.erb
+++ b/catalog-metadata.html.md.erb
@@ -54,7 +54,7 @@ The example below contains a catalog of one service, having one service plan. Of
 {
    "services":[
       {
-	 "id":"766fa866-a950-4b12-adff-c11fa4cf8fdc",
+     "id":"766fa866-a950-4b12-adff-c11fa4cf8fdc",
          "name":"cloudamqp",
          "description":"Managed HA RabbitMQ servers in the cloud",
          "requires":[
@@ -81,7 +81,7 @@ The example below contains a catalog of one service, having one service plan. Of
          "plans":[
             {
                "id":"024f3452-67f8-40bc-a724-a20c4ea24b1c",
-	       "name":"bunny",
+           "name":"bunny",
                "description":"A mid-sided plan",
                "metadata":{
                   "bullets":[

--- a/dashboard-sso.html.md.erb
+++ b/dashboard-sso.html.md.erb
@@ -34,25 +34,25 @@ When this client is not present in the cf-release manifest, Cloud Controller can
 
 1.  A service broker must include the `dashboard_client` field in the JSON response from its [catalog endpoint](api.html#catalog-mgmt) for each service implementing this feature. A valid response would appear as follows:
 
-	  ```
-	  {
-	    "services": [
-	      {
-	        "id": "44b26033-1f54-4087-b7bc-da9652c2a539",
-	        ...
-	        "dashboard_client": {
-	          "id": "p-mysql-client",
-	          "secret": "p-mysql-secret",
-	          "redirect_uri": "http://p-mysql.example.com"
-	        }
-	      }
-	    ]
-	  }
-	  ```
-	The `dashboard_client` field is a hash containing three fields:
-	- `id` is the unique identifier for the OAuth2 client that will be created for your service dashboard on the token server (UAA), and will be used by your dashboard to authenticate with the token server (UAA).
-	- `secret` is the shared secret your dashboard will use to authenticate with the token server (UAA).
-	- `redirect_uri` is used by the token server as an additional security precaution. UAA will not provide a token if the callback URL declared by the service dashboard doesn't match the domain name in `redirect_uri`. The token server matches on the domain name, so any paths will also match; e.g. a service dashboard requesting a token and declaring a callback URL of `http://p-mysql.example.com/manage/auth` would be approved if `redirect_uri` for its client is `http://p-mysql.example.com/`.
+      ```
+      {
+        "services": [
+          {
+            "id": "44b26033-1f54-4087-b7bc-da9652c2a539",
+            ...
+            "dashboard_client": {
+              "id": "p-mysql-client",
+              "secret": "p-mysql-secret",
+              "redirect_uri": "http://p-mysql.example.com"
+            }
+          }
+        ]
+      }
+      ```
+    The `dashboard_client` field is a hash containing three fields:
+    - `id` is the unique identifier for the OAuth2 client that will be created for your service dashboard on the token server (UAA), and will be used by your dashboard to authenticate with the token server (UAA).
+    - `secret` is the shared secret your dashboard will use to authenticate with the token server (UAA).
+    - `redirect_uri` is used by the token server as an additional security precaution. UAA will not provide a token if the callback URL declared by the service dashboard doesn't match the domain name in `redirect_uri`. The token server matches on the domain name, so any paths will also match; e.g. a service dashboard requesting a token and declaring a callback URL of `http://p-mysql.example.com/manage/auth` would be approved if `redirect_uri` for its client is `http://p-mysql.example.com/`.
 
 1. When a service broker which advertises the `dashboard_client` property for any of its services is [added or updated](managing-service-brokers.html), Cloud Controller will create or update UAA clients as necessary. This client will be used by the service dashboard to authenticate users.
 
@@ -82,16 +82,16 @@ A service dashboard should implement the OAuth2 Authorization Code Grant type ([
 
 1. When a user visits the service dashboard at the value of `dashboard_url`, the dashboard should redirect the user's browser to the Authorization Endpoint and include its `client_id`, a `redirect_uri` (callback URL with domain matching the value of `dashboard_client.redirect_uri`), and list of requested scopes.
 
-	Scopes are permissions included in the token a dashboard client will receive from UAA, and which Cloud Controller uses to enforce access. A client should request the minimum scopes it requires. The minimum scopes required for this workflow are `cloud_controller_service_permissions.read` and `openid`. For an explanation of the scopes available to dashboard clients, see [On Scopes](#on-scopes).
+    Scopes are permissions included in the token a dashboard client will receive from UAA, and which Cloud Controller uses to enforce access. A client should request the minimum scopes it requires. The minimum scopes required for this workflow are `cloud_controller_service_permissions.read` and `openid`. For an explanation of the scopes available to dashboard clients, see [On Scopes](#on-scopes).
 
 1. UAA authenticates the user by redirecting the user to the Login Server, where the user then approves or denies the scopes requested by the service dashboard. The user is presented with human readable descriptions for permissions representing each scope. After authentication, the user's browser is redirected back to the Authorization endpoint on UAA with an authentication cookie for the UAA.
 
 1. Assuming the user grants access, UAA redirects the user's browser back to the value of `redirect_uri` the dashboard provided in its request to the Authorization Endpoint.  The `Location` header in the response includes an authorization code.
 
-	```
-	HTTP/1.1 302 Found
-	Location: https://p-mysql.example.com/manage/auth?code=F45jH
-	```
+    ```
+    HTTP/1.1 302 Found
+    Location: https://p-mysql.example.com/manage/auth?code=F45jH
+    ```
 
 1. The dashboard UI should then request an access token from the Token Endpoint by including the authorization code received in the previous step.  When making the request the dashboard must authenticate with UAA by passing the client `id` and `secret` in a basic auth header. UAA will verify that the client id matches the client it issued the code to. The dashboard should also include the `redirect_uri` used to obtain the authorization code for verification.
 

--- a/volume-services.html.md.erb
+++ b/volume-services.html.md.erb
@@ -90,16 +90,16 @@ Cloud Foundry application developers may want their applications to mount one or
 
 ### Example ###
 <pre class="terminal">
-	{
-	  ...
-	  "volume_mounts": {
-	    "container_path": "/data/images",
-	    "mode": "r",
-	    "private": {
-	      "driver": "cephdriver",
-	      "group_id": "bc2c1eab-05b9-482d-b0cf-750ee07de311",
-	      "config": "Some arbitrary configuration string. Could be a marshalled json"
-	    }
-	  }
-	}
+    {
+      ...
+      "volume_mounts": {
+        "container_path": "/data/images",
+        "mode": "r",
+        "private": {
+          "driver": "cephdriver",
+          "group_id": "bc2c1eab-05b9-482d-b0cf-750ee07de311",
+          "config": "Some arbitrary configuration string. Could be a marshalled json"
+        }
+      }
+    }
 </pre>


### PR DESCRIPTION
Spaces, it is aligned  to view code with any editor, including the web page view (such as in the GitHub code). When use tabs, the view on the page is chaos, and it is terrible to mix tabs and spaces.