### PR TITLE
Fix example being badly parsed by MarkDown. Fixes #132.

### DIFF
--- a/api-v2.9.html.md.erb
+++ b/api-v2.9.html.md.erb
@@ -706,11 +706,13 @@ For success responses, the following fields are supported. Others will be ignore
 </tr>
 </tboby>
 </table>
+
 \* Fields with an asterisk are required.
+
 <pre class="terminal">
 {
- "dashboard_url": "http://example-dashboard.example.com/9189kdfsk0vfnku",
- "operation": "task_10"
+  "dashboard_url": "http://example-dashboard.example.com/9189kdfsk0vfnku",
+  "operation": "task_10"
 }
 </pre>
 


### PR DESCRIPTION
Looks like the markdown was being affected by the line above being too close.