### PR TITLE
Service Broker API 2.10 docs:

### DIFF
--- a/_version_table.html.erb
+++ b/_version_table.html.erb
@@ -16,9 +16,10 @@ brokers are upgraded.
     <tbody>
       <tr>
         <td>
-          <a href="api.html">2.9</a><br/>
+          <a href="api.html">2.10</a><br/>
         </td>
         <td>
+          <a href="api-v2.9.html">2.9</a><br/>
           <a href="api-v2.8.html">2.8</a><br/>
           <a href="api-v2.7.html">2.7</a><br/>
           <a href="api-v2.6.html">2.6</a><br/>

--- a/api-v2.10.html.md.erb
+++ b/api-v2.10.html.md.erb
@@ -1,0 +1,1403 @@
+---
+title: Service Broker API v2.10
+owner: Services API
+---
+
+<strong><%= modified_date %></strong>
+
+## <a id='changelog'></a>Document Changelog ##
+
+[v2 API Change Log](v2-api-changelog.html)
+
+<%= partial "version_table.html" %>
+
+## <a id='changes'></a>Changes ##
+
+### <a id='change-policy'></a>Change Policy ###
+
+* Existing endpoints and fields will not be removed or renamed.
+* New optional endpoints, or new HTTP methods for existing endpoints, may be
+added to enable support for new features.
+* New fields may be added to existing request/response messages.
+These fields must be optional and should be ignored by clients and servers
+that do not understand them.
+
+### <a id='api-changes-since-v2-8'></a>Changes Since v2.9 ###
+
+1. Backward incompatible changes to experimental volume_mounts field in service bind response.
+
+## <a id='dependencies'></a>Dependencies ##
+
+v2.10 of the services API has been supported since:
+
+* [TBD](https://github.com/cloudfoundry/cf-release/tree/v240) of [cf-release](https://github.com/cloudfoundry/cf-release/)
+* vTBD of the Cloud Controller API
+* CLI [v6.14.0](https://github.com/cloudfoundry/cli/releases/tag/v6.14.0)
+
+## <a id='api-overview'></a>API Overview ##
+
+The Cloud Foundry services API defines the contract between the Cloud
+Controller and the service broker.
+The broker is expected to implement several HTTP (or HTTPS) endpoints
+underneath a URI prefix.
+One or more services can be provided by a single broker, and load balancing
+enables horizontal scalability of redundant brokers.
+Multiple Cloud Foundry instances can be supported by a single broker using
+different URL prefixes and credentials.
+
+<%= image_tag("../images/v2services-new.png", :width =>"960", :height =>"720", :style => 'background-color:#fff') %>
+
+## <a id='api-version-header'></a>API Version Header ##
+
+Requests from the Cloud Controller to the broker contain a header that defines
+the version number of the Broker API that Cloud Controller will use.
+This header will be useful in future minor revisions of the API to allow
+brokers to reject requests from Cloud Controllers that they do not understand.
+While minor API revisions will always be additive, it is possible that brokers
+will come to depend on a feature that was added after 2.0, so they may use this
+header to reject the request.
+Error messages from the broker in this situation should inform the operator of
+what the required and actual version numbers are so that an operator can go
+upgrade Cloud Controller and resolve the issue.
+A broker should respond with a `412 Precondition Failed` message when rejecting
+a request.
+
+The version numbers are in the format `MAJOR.MINOR`, using semantic versioning
+such that 2.9 comes before 2.10.
+An example of this header as of publication time is:
+
+`X-Broker-Api-Version: 2.10`
+
+## <a id='authentication'></a>Authentication ##
+
+Cloud Controller (final release v145+) authenticates with the Broker using HTTP
+basic authentication (the `Authorization:` header) on every request and will
+reject any broker registrations that do not contain a username and password.
+The broker is responsible for checking the username and password and returning
+a `401 Unauthorized` message if credentials are invalid.
+Cloud Controller supports connecting to a broker using SSL if additional
+security is desired.
+
+## <a id='catalog-mgmt'></a>Catalog Management ##
+
+The first endpoint that a broker must implement is the service catalog.
+Cloud Controller will initially fetch this endpoint from all brokers and make
+adjustments to the user-facing service catalog stored in the Cloud Controller
+database.
+If the catalog fails to initially load or validate, Cloud Controller will not
+allow the operator to add the new broker and will give a meaningful error
+message.
+Cloud Controller will also update the catalog whenever a broker is updated, so
+you can use `update-service-broker` with no changes to force a catalog refresh.
+
+When Cloud Controller fetches a catalog from a broker, it will compare the
+broker's id for services and plans with the `unique_id` values for services and
+plans in the  Cloud Controller database.
+If a service or plan in the broker catalog has an id that is not present
+amongst the `unique_id` values in the database, a new record will be added to
+the database.
+If services or plans in the database are found with `unique_id`s that match the
+broker catalog's id, Cloud Controller will update the records to match
+the broker’s catalog.
+
+If the database has plans which are not found in the broker catalog, and there
+are no associated service instances, Cloud Controller will remove these plans
+from the database. Cloud Controller will then delete services that do not have associated plans
+from the database.
+If the database has plans which are not found in the broker catalog, and there
+**are** provisioned instances, the plan will be marked “inactive” and will
+no longer be visible in the marketplace catalog or be provisionable.
+
+
+### Request ###
+
+#### Route ####
+`GET /v2/catalog`
+
+#### cURL ####
+<pre class="terminal">
+ $ curl -H "X-Broker-API-Version: 2.10" http://username:password@broker-url/v2/catalog
+</pre>
+
+### Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status Code</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>200 OK</td>
+  <td>The expected response body is below.</td>
+</tr>
+</tbody>
+</table>
+
+#### Body - Schema of Service Objects ####
+
+CLI and web clients have different needs with regard to service and plan names.
+A CLI-friendly string is all lowercase, with no spaces.
+Keep it short -- imagine a user having to type it as an argument for a longer
+command.
+A web-friendly display name is camel-cased with spaces and punctuation supported.
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>services*</td>
+  <td>array-of-service-objects</td>
+  <td>Schema of service objects defined below.</td>
+</tr>
+</tbody>
+</table>
+
+<h5> Service Objects </h5>
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;name*</td>
+  <td>string</td>
+  <td>The CLI-friendly name of the service that will appear in the catalog. All lowercase, no spaces.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;id*</td>
+  <td>string</td>
+  <td>An identifier used to correlate this service in future requests to the catalog. This must be unique within Cloud Foundry, using a GUID is recommended. </td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;description*</td>
+  <td>string</td>
+  <td>A short description of the service that will appear in the catalog.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;tags</td>
+  <td>array-of-strings</td>
+  <td>Tags provide a flexible mechanism to expose a classification, attribute, or base technology of a service, enabling equivalent services to be swapped out without changes to dependent logic in applications, buildpacks, or other services. E.g. mysql, relational, redis, key-value, caching, messaging, amqp.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;requires</td>
+  <td>array-of-strings</td>
+  <td>A list of permissions that the user would have to give the service, if they provision it. The only permissions currently supported are <tt>syslog_drain</tt>, <tt>route_forwarding</tt> and <tt>volume_mount</tt>; for more info see <a href="app-log-streaming.html">Application Log Streaming</a>, <a href="route-services.html">Route Services</a> and <a href="volume-services-v2.10.html">Volume Services</a>.</td>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;max_db_per_node:</td>
+  <td>strings</td>
+  <td></td>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;bindable*</td>
+  <td>boolean</td>
+  <td>Whether the service can be bound to applications.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;metadata</td>
+  <td>object</td>
+  <td>A list of metadata for a service offering. For more information, see <a href="catalog-metadata.html">Service Metadata</a>.</td>
+</tr>
+<tr>
+  <td><a href="#DObject">&nbsp;&nbsp;&nbsp;dashboard_client</a></td>
+  <td>object</td>
+  <td>Contains the data necessary to activate the <a href="dashboard-sso.html">Dashboard SSO feature</a> for this service</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;plan_updateable</td>
+  <td>boolean</td>
+  <td>
+    Whether the service supports upgrade/downgrade for some plans.
+    <br/>
+    Please note that the misspelling of the attribute <i>plan_updatable</i> to <i>plan_updateable</i> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.
+  </td>
+</tr>
+<tr>
+  <td><a href="#PObject">&nbsp;&nbsp;&nbsp;plans*</a></td>
+  <td>array-of-objects</td>
+  <td>A list of plans for this service, schema is defined below.</td>
+</tr>
+</tbody>
+</table>
+
+<h5> Dashboard Client Object <a name="DObject"></a> </h5>
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;id</td>
+  <td>string</td>
+  <td>The id of the Oauth2 client that the service intends to use. The name may be taken, in which case the updat will return an error to the operator</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;secret</td>
+  <td>string</td>
+  <td>A secret for the dashboard client</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;redirect_uri</td>
+  <td>string</td>
+  <td>A domain for the service dashboard that will be whitelisted by the UAA to enable SSO</td>
+</tr>
+</tbody>
+</table>
+
+
+<h5> Plan Object <a name="PObject"></a> </h5>
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;id*</td>
+  <td>string</td>
+  <td>An identifier used to correlate this plan in future requests to the catalog. This must be unique within Cloud Foundry, using a GUID is recommended.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;name*</td>
+  <td>string</td>
+  <td>The CLI-friendly name of the plan that will appear in the catalog. All lowercase, no spaces.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;description*</td>
+  <td>string</td>
+  <td>A short description of the service that will appear in the catalog.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;metadata</td>
+  <td>object</td>
+  <td>A list of metadata for a service plan. For more information, see <a href="catalog-metadata.html">Service Metadata</a>.</td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;free</td>
+  <td>boolean</td>
+  <td>This field allows the plan to be limited by the non_basic_services_allowed field in a Cloud Foundry Quota, see <a href="http://docs.cloudfoundry.org/running/managing-cf/quota-plans.html">Quota Plans</a>. Default: true</td>
+</tr>
+</tbody>
+</table>
+
+\* Fields with an asterisk are required.
+
+<pre>
+{
+  "services": [{
+    "name": "fake-service",
+    "id": "acb56d7c-XXXX-XXXX-XXXX-feb140a59a66",
+    "description": "fake service",
+    "tags": ["no-sql", "relational"],
+    "requires": ["route_forwarding"],
+    "max_db_per_node": 5,
+    "bindable": true,
+    "metadata": {
+      "provider": {
+        "name": "The name"
+      },
+      "listing": {
+        "imageUrl": "http://example.com/cat.gif",
+        "blurb": "Add a blurb here",
+        "longDescription": "A long time ago, in a galaxy far far away..."
+      },
+      "displayName": "The Fake Broker"
+    },
+    "dashboard_client": {
+      "id": "398e2f8e-XXXX-XXXX-XXXX-19a71ecbcf64",
+      "secret": "277cabb0-XXXX-XXXX-XXXX-7822c0a90e5d",
+      "redirect_uri": "http://localhost:1234"
+    },
+    "plan_updateable": true,
+    "plans": [{
+      "name": "fake-plan",
+      "id": "d3031751-XXXX-XXXX-XXXX-a42377d3320e",
+      "description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections",
+      "max_storage_tb": 5,
+      "metadata": {
+        "cost": 0,
+        "bullets": [{
+          "content": "Shared fake server"
+        }, {
+          "content": "5 TB storage"
+        }, {
+          "content": "40 concurrent connections"
+        }]
+      }
+    }, {
+      "name": "fake-async-plan",
+      "id": "0f4008b5-XXXX-XXXX-XXXX-dace631cd648",
+      "description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async",
+      "max_storage_tb": 5,
+      "metadata": {
+        "cost": 0,
+        "bullets": [{
+          "content": "40 concurrent connections"
+        }]
+      }
+    }, {
+      "name": "fake-async-only-plan",
+      "id": "8d415f6a-XXXX-XXXX-XXXX-e61f3baa1c77",
+      "description": "Shared fake Server, 5tb persistent disk, 40 max concurrent connections. 100 async",
+      "max_storage_tb": 5,
+      "metadata": {
+        "cost": 0,
+        "bullets": [{
+          "content": "40 concurrent connections"
+        }]
+      }
+    }]
+  }]
+}
+</pre>
+
+
+### <a id='create-broker'></a>Adding a Broker to Cloud Foundry ###
+
+Once you've implemented the first endpoint `GET /v2/catalog` above, you'll want
+to [register the broker with CF](managing-service-brokers.html#register-broker)
+to make your services and plans available to end users.
+
+## <a id='asynchronous-operations'></a>Asynchronous Operations ##
+
+Previously, Cloud Foundry only supported synchronous integration with service brokers. Brokers must return a valid response within 60 seconds and if the response is `201 CREATED`, users expect a service instance to be usable. This limits the services brokers can offer to those that can be provisioned in 60 seconds; brokers could return a success prematurely, but this leaves users wondering why their service instance is not usable and when it will be.
+
+With support for Asynchronous Operations, brokers still must respond within 60 seconds but may now return a `202 ACCEPTED`, indicating that the requested operation has been accepted but is not complete. This triggers Cloud Foundry to poll a new endpoint `/v2/service_instances/:guid/last_operation` until the broker indicates that the requested operation has succeeded or failed. During the intervening time, end users are able to discover the state of the requested operation using Cloud Foundry API clients such as the CLI.
+
+For an operation to be executed asynchronously, all three components (CF API client, CF, and broker) must support the feature. The parameter `accepts_incomplete=true` must be passed in a request by the CF API client, triggering CF to include the same parameter in a request to the broker. The broker can then choose to execute the request synchronously or asynchronously.
+
+If the broker executes the request asynchronously, the response must use the status code `202 ACCEPTED`; the response body should be the same as if the broker were serving the request synchronously.
+
+<p class='note'><strong>Note:</strong> Asynchronous Operations are currently supported only for provision, update, and deprovision. Bind and unbind will be added once the feature is considered stable.</p>
+
+If the `accepts_incomplete=true` parameter is not included, and the broker cannot fulfill the request synchronously (guaranteeing that the operation is complete on response), then the broker should reject the request with the status code `422 UNPROCESSABLE ENTITY` and the following body:
+
+<pre class="terminal">
+{
+  "error": "AsyncRequired",
+  "description": "This service plan requires client support for asynchronous service operations."
+}
+</pre>
+
+To execute a request synchronously, the broker need only return the usual status codes; `201 CREATED` for create, and `200 OK` for update and delete.
+
+### <a id='sequence-diagram'></a>Sequence Diagram ###
+<a href='images/async-service-broker-flow.png' target='_blank'>
+  <%= image_tag("images/async-service-broker-flow.png", :width =>"1250", :height =>"823", :style => 'background-color:#fff') %>
+</a>
+
+### <a id='blocking'></a>Blocking Operations ###
+
+The Cloud Controller ensures that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the Cloud Controller will not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress will get an HTTP 400 with error message "Another operation for this service instance is in progress."
+
+### <a id='when-to-use-async'></a>When to use Asynchronous Service Operations ###
+
+Service brokers should respond to all Cloud Controller requests within 60 seconds. Brokers that can guarantee completion of the requested operation with the response may return the synchronous response (e.g. `201 CREATED` for a provision request). Brokers that cannot guarantee completion of the operation with the response should implement support for asynchronous provisioning. Support for synchronous or asynchronous responses may vary by service offering, even by service plan.
+
+## <a id='polling'></a>Polling Last Operation (async only) ##
+
+When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), Cloud Foundry will begin to poll the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response must contain the field `state` and an optional field `description`.
+
+Valid values for `state` are `in progress`, `succeeded`, and `failed`. Cloud Foundry will poll the `last_operation` endpoint as long as the broker returns `"state": "in progress"`. Returning `"state": "succeeded"` or `"state": "failed"` will cause Cloud Foundry to cease polling. The value provided for `description` will be passed through to the CF API client and can be used to provide additional detail for users about the state of the operation.
+
+### Request ###
+
+##### Route #####
+`GET /v2/service_instances/:instance_id/last_operation`
+
+##### Parameters #####
+
+The request provides these query string parameters as useful hints for brokers.
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Query-String Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>service_id</td>
+  <td>string</td>
+  <td>ID of the service from the catalog.</td>
+</tr>
+<tr>
+  <td>plan_id</td>
+  <td>string</td>
+  <td>ID of the plan from the catalog.</td>
+</tr>
+<tr>
+  <td>operation</td>
+  <td>string</td>
+  <td>The field optionally returned by the service broker on Provision, Update, Deprovision async responses. Represents any state the service broker responsed with as a URL encoded string.</a>.</td>
+</tr>
+</tbody>
+</table>
+
+<p class="note"><strong>Note:</strong> Although the request query parameters <code>service_id</code> and <code>plan_id</code> are not required, Cloud Controller includes them on all <code>last_operation</code> requests it makes to service brokers.</p>
+
+##### cURL #####
+<pre class="terminal">
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id/last_operation
+</pre>
+
+### Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status Code</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>200 OK</td>
+  <td>The expected response body is below.</td>
+</tr>
+<tr>
+  <td>410 GONE</td>
+  <td>Appropriate only for asynchronous delete requests. Cloud Foundry will consider this response a success and remove the resource from its database. The expected response body is <code>{}</code>. Returning this while Cloud Foundry is polling for create or update operations will be interpreted as an invalid response and Cloud Foundry will continue polling.</td>
+</tr>
+</tbody>
+</table>
+
+Responses with any other status code will be interpreted as an error or invalid response; Cloud Foundry will continue polling until the broker returns a valid response or the [maximum polling duration](#max-polling-duration) is reached. Brokers may use the `description` field to expose user-facing error messages about the operation state; for more info see [Broker Errors](api.html#broker-errors).
+
+##### Body #####
+
+All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For success responses, the following fields are valid.
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>state*</td>
+  <td>string</td>
+  <td>Valid values are <code>in progress</code>, <code>succeeded</code>, and <code>failed</code>. While <code>"state": "in progress"</code>, Cloud Foundry will continue polling. A response with <code>"state": "succeeded"</code> or <code>"state": "failed"</code> will cause Cloud Foundry to cease polling.</td>
+</tr>
+<tr>
+  <td>description</td>
+  <td>string</td>
+  <td>Optional field. A user-facing message displayed to the Cloud Foundry API client. Can be used to tell the user details about the status of the operation.</td>
+</tr>
+</tboby>
+</table>
+
+\* Fields with an asterisk are required.
+
+<pre class="terminal">
+{
+  "state": "in progress",
+  "description": "Creating service (10% complete)."
+}
+</pre>
+
+### <a id='polling-interval'></a> Polling Interval ###
+When a broker responds asynchronously to a request from Cloud Foundry containing the `accepts_incomplete=true` parameter, Cloud Foundry will poll the broker for the operation state at a configured interval. The Cloud Foundry operator can configure this interval in the BOSH deployment manifest using the property `properties.cc.broker_client_default_async_poll_interval_seconds` (defaults to 60 seconds). The maximum supported polling interval is 86400 seconds (24 hours).
+
+### <a id='max-polling-duration'></a>Maximum Polling Duration ###
+When a broker responds asynchronously to a request from Cloud Foundry containing the `accepts_incomplete=true` parameter, Cloud Foundry will poll the broker for the operation state until the broker response includes `"state":"succeeded"` or `"state":"failed"`, or until a maximum polling duration is reached. If the max polling duration is reached, Cloud Foundry will cease polling and the operation state will be considered `failed`. The Cloud Foundry operator can configure this max polling duration in the BOSH deployment manifest using the property `properties.cc.broker_client_max_async_poll_duration_minutes` (defaults to 10080 minutes or 1 week).
+
+### <a id='additional-resources'></a>Additional Resources ###
+
+* An example broker that implements this feature can be found at [Example Service Brokers](examples.html).
+* A demo video of the CLI user experience using the above broker can be found [here](https://youtu.be/Ij5KSKrAq9Q).
+
+## <a id='provisioning'></a>Provisioning ##
+
+When the broker receives a provision request from Cloud Controller, it should
+synchronously take whatever action is necessary to create a new service
+resource for the developer.
+The result of provisioning varies by service type, although there are a few
+common actions that work for many services.
+For a MySQL service, provisioning could result in:
+
+* An empty dedicated `mysqld` process running on its own VM.
+* An empty dedicated `mysqld` process running in a lightweight container on a
+shared VM.
+* An empty dedicated `mysqld` process running on a shared VM.
+* An empty dedicated database, on an existing shared running `mysqld`.
+* A database with business schema already there.
+* A copy of a full database, for example a QA database that is a copy of the
+production database.
+
+For non-data services, provisioning could just mean getting an account on an
+existing system.
+
+### Request ###
+
+##### Route #####
+`PUT /v2/service_instances/:instance_id`
+
+<p class="note"><strong>Note</strong>: The <code>:instance_id</code> of a service instance is provided by the Cloud Controller. This ID will be used for future requests (bind and deprovision), so the broker must use it to correlate the resource it creates.</p>
+
+##### Body #####
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Request field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>organization_guid*</td>
+  <td>string</td>
+  <td>The Cloud Controller GUID of the organization under which the service is to be provisioned. Although most brokers will not use this field, it could be helpful in determining data placement or applying custom business rules.</td>
+</tr>
+<tr>
+  <td>plan_id*</td>
+  <td>string</td>
+  <td>The ID of the plan within the above service (from the catalog endpoint) that the user would like provisioned. Because plans have identifiers unique to a broker, this is enough information to determine what to provision.</td>
+</tr>
+<tr>
+  <td>service_id*</td>
+  <td>string</td>
+  <td>The ID of the service within the catalog above.</td>
+</tr>
+<tr>
+  <td>space_guid*</td>
+  <td>string</td>
+  <td>Similar to organization_guid, but for the space.</td>
+</tr>
+<tr>
+  <td>parameters</td>
+  <td>JSON object</td>
+  <td>Cloud Foundry API clients can provide a JSON object of configuration parameters with their request and this value will be passed through to the service broker. Brokers are responsible for validation.</td>
+</tr>
+<tr>
+  <td>accepts_incomplete</td>
+  <td>boolean</td>
+  <td>A value of true indicates that both the Cloud Controller and the requesting client support asynchronous provisioning. If this parameter is not included in the request, and the broker can only provision an instance of the requested plan asynchronously, the broker should reject the request with a 422 as described below.</td>
+</tr>
+</tbody>
+</table>
+
+\* Fields with an asterisk are required.
+
+<pre class="terminal">
+{
+  "organization_guid": "org-guid-here",
+  "plan_id":           "plan-guid-here",
+  "service_id":        "service-guid-here",
+  "space_guid":        "space-guid-here",
+  "parameters":        {
+    "parameter1": 1,
+    "parameter2": "value"
+  }
+}
+</pre>
+
+##### cURL #####
+<pre class="terminal">
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id -d '{
+  "organization_guid": "org-guid-here",
+  "plan_id":           "plan-guid-here",
+  "service_id":        "service-guid-here",
+  "space_guid":        "space-guid-here",
+  "parameters":        {
+    "parameter1": 1,
+    "parameter2": "value"
+  }
+}' -X PUT -H "X-Broker-API-Version: 2.10" -H "Content-Type: application/json"
+</pre>
+
+In this case, `instance_id` refers to the service instance id generated by Cloud
+Controller
+
+### Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status Code</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>201 Created</td>
+  <td>Service instance has been created. The expected response body is below.</td>
+</tr>
+<tr>
+  <td>200 OK</td>
+  <td>
+    May be returned if the service instance already exists and the requested parameters are identical to the existing service instance.
+    The expected response body is below.
+  </td>
+</tr>
+<tr>
+  <td>202 Accepted</td>
+  <td>Service instance creation is in progress. This triggers Cloud Controller to poll the <a href="#polling">Service Instance Last Operation Endpoint</a> for operation status.</td>
+</tr>
+<tr>
+  <td>409 Conflict</td>
+  <td>Should be returned if the requested service instance already exists. The expected response body is <code>{}</code>.</td>
+</tr>
+<tr>
+  <td>422 Unprocessable Entity</td>
+  <td>Should be returned if the broker only supports asynchronous provisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.</td>
+</tr>
+</tbody>
+</table>
+
+Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+
+##### Body #####
+
+All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>dashboard_url</td>
+  <td>string</td>
+  <td>The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL should contain enough information for the dashboard to identify the resource being accessed ("9189kdfsk0vfnku" in the example below). For information on how users can authenticate with service dashboards via SSO, see <a href="dashboard-sso.html">Dashboard Single Sign-On</a>.</td>
+</tr>
+<tr>
+  <td>operation</td>
+  <td>string</td>
+  <td>For async responses, service brokers can return operation state as a string. This field will be provided back to the service broker on <code>last_operation</code> requests as a URL encoded query param.</a>.</td>
+</tr>
+</tboby>
+</table>
+\* Fields with an asterisk are required.
+<pre class="terminal">
+{
+ "dashboard_url": "http://example-dashboard.example.com/9189kdfsk0vfnku",
+ "operation": "task_10"
+}
+</pre>
+
+
+## <a id='updating_service_instance'></a>Updating a Service Instance ##
+
+Brokers that implement this endpoint can enable users to modify attributes of an existing service instance. The first attribute Cloud Foundry supports users modifying is the service plan. This effectively enables users to upgrade or downgrade their service instance to other plans. To see how users make these requests, see [Managing Services](../devguide/services/managing-services.html#update_service).
+
+To enable this functionality, a broker declares support for each service by including `plan_updateable: true` in its [catalog endpoint](#catalog-mgmt). If this optional field is not included, Cloud Foundry will return a meaningful error to users for any plan change request, and will not make an API call to the broker. If this field is included and configured as true, Cloud Foundry will make API calls to the broker for all plan change requests, and it is up to the broker to validate whether a particular permutation of plan change is supported. Not all permutations of plan changes are expected to be supported. For example, a service may support upgrading from plan "shared small" to "shared large" but not to plan "dedicated". If a particular plan change is not supported, the broker should return a meaningful error message in response.
+
+### Request ###
+
+##### Route #####
+`PATCH /v2/service_instances/:instance_id`
+
+<p class="note"><strong>Note</strong>: <code>:instance_id</code> is the global unique ID of a previously-provisioned service instance.</p>
+
+##### Body #####
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Request Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>service_id*</td>
+  <td>string</td>
+  <td>The ID of the service within the catalog above.</td>
+</tr>
+<tr>
+  <td>plan_id</td>
+  <td>string</td>
+  <td>ID of the new plan from the catalog.</td>
+</tr>
+<tr>
+  <td>parameters</td>
+  <td>JSON object</td>
+  <td>Cloud Foundry API clients can provide a JSON object of configuration parameters with their request and this value will be passed through to the service broker. Brokers are responsible for validation.</td>
+</tr>
+<tr>
+  <td>previous_values</td>
+  <td>object</td>
+  <td>Information about the instance prior to the update.</td>
+</tr>
+<tr>
+  <td>previous_values.plan_id</td>
+  <td>string</td>
+  <td>ID of the plan prior to the update.</td>
+</tr>
+<tr>
+  <td>previous_values.service_id</td>
+  <td>string</td>
+  <td>ID of the service for the instance.</td>
+</tr>
+<tr>
+  <td>previous_values.organization_id</td>
+  <td>string</td>
+  <td>ID of the organization containing the instance.</td>
+</tr>
+<tr>
+  <td>previous_values.space_id</td>
+  <td>string</td>
+  <td>ID of the space containing the instance..</td>
+</tr>
+<tr>
+  <td>accepts_incomplete</td>
+  <td>boolean</td>
+  <td>A value of true indicates that both the Cloud Controller and the requesting client support asynchronous update. If this parameter is not included in the request, and the broker can only update an instance of the requested plan asynchronously, the broker should reject the request with a 422 as described below.</td>
+</tr>
+</tbody>
+</table>
+
+\* Fields with an asterisk are required.
+
+<pre class="terminal">
+{
+  "service_id": "service-guid-here",
+  "plan_id": "plan-guid-here",
+  "parameters":        {
+    "parameter1": 1,
+    "parameter2": "value"
+  },
+  "previous_values": {
+    "plan_id": "old-plan-guid-here",
+    "service_id": "service-guid-here",
+    "organization_id": "org-guid-here",
+    "space_id": "space-guid-here"
+  }
+}
+</pre>
+
+##### cURL #####
+<pre class="terminal">
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id -d '{
+  "service_id": "service-guid-here",
+  "plan_id": "plan-guid-here",
+  "parameters":        {
+    "parameter1": 1,
+    "parameter2": "value"
+  },
+  "previous_values": {
+    "plan_id": "old-plan-guid-here",
+    "service_id": "service-guid-here",
+    "organization_id": "org-guid-here",
+    "space_id": "space-guid-here"
+  }
+}' -X PATCH -H "X-Broker-API-Version: 2.10" -H "Content-Type: application/json"
+</pre>
+
+### Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status Code</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>200 OK</td>
+  <td>New plan is effective. The expected response body is <code>{}</code>.</td>
+</tr>
+<tr>
+  <td>202 Accepted</td>
+  <td>Service instance update is in progress. This triggers Cloud Controller to poll the <a href="#polling">Service Instance Last Operation Endpoint</a> for operation status.</td>
+</tr>
+<tr>
+  <td>422 Unprocessable entity</td>
+  <td>
+    May be returned if the particular plan change requested is not supported or if the request cannot currently be fulfilled due to the state of the instance (eg. instance utilization is over the quota of the requested plan). Broker should include a user-facing message in the body; for details see <a href="#broker-errors">Broker Errors</a>.  Additionally, a <code>422</code> can also be returned if the broker only supports asynchronous update for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code></a>.
+  </td>
+</tr>
+</tbody>
+</table>
+
+Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+
+##### Body #####
+
+All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>operation</td>
+  <td>string</td>
+  <td>For async responses, service brokers can return operation state as a string. This field will be provided back to the service broker on `last_operation` requests as a URL encoded query param.</a>.</td>
+</tr>
+</tboby>
+</table>
+\* Fields with an asterisk are required.
+<pre class="terminal">
+{
+ "operation": "task_10"
+}
+</pre>
+
+
+## <a id='binding'></a>Binding ##
+
+<p class="note"><strong>Note</strong>: Not all services must be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable should declare them as such using <code>bindable: true</code> in the <a href="#catalog-mgmt">Catalog</a>. Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
+
+### <a id='binding-types'></a>Types of Binding ###
+
+#### <a id='binding-credentials'></a>Credentials ####
+
+Credentials are a set of information used by an application or a user to utilize the service instance. If `bindable:true` is declared for a service in the catalog endpoint, users may request generation of credentials either by binding the service instance to an application or by creating a service key. When a service instance is bound to an app, Cloud Foundry will send the app id with the request. When a service key is created, the app id is not included. If the broker supports generation of credentials it should return `credentials` in the response. Credentials should be unique whenever possible, so access can be revoked for one application or user without affecting another. For more information on credentials, see [Binding Credentials](binding-credentials.html).
+
+#### <a id='binding-syslog-drain'></a>Application Log Streaming ####
+
+In response to a bind request for an application (`app_id` included), a broker may also enable streaming of application logs from Cloud Foundry to a consuming service instance by returning `syslog_drain_url`. For details, see [Application Log Streaming](app-log-streaming.html).
+
+#### <a id='binding-route-services'></a>Route Services ####
+
+If a broker has declared `"requires":["route_forwarding"]` for a service in the Catalog endpoint, Cloud Foundry will permit a user to bind a service to a route. When bound to a route, the route itself will be sent with the bind request. A route is an address used by clients to reach apps mapped to the route. In response a broker may return a `route_service_url` which Cloud Foundry will use to proxy any request for the route to the service instance at URL specified by `route_service_url`. A broker may declare `"requires":["route_forwarding"]` but not return `route_service_url`; this enables a broker to dynamically configure a network component already in the request path for the route, requiring no change in the Cloud Foundry router. For more information, see [Route Services](route-services.html).
+
+#### <a id='binding-volume-services'></a>Volume Services (Experimental)####
+
+If a broker has declared `"requires":["volume_mount"]` for a service in the Catalog endpoint, Cloud Foundry will permit a user to bind one or more volumes to an application.  In response to a bind request a volume service broker should return a set of `volume_mount` instructions that Cloud Foundry will ensure are mounted into the application's containers.  For more information, see [Volume Services](volume-services-v2.10.html)
+
+### Request ###
+
+##### Route #####
+`PUT /v2/service_instances/:instance_id/service_bindings/:binding_id`
+
+<p class="note"><strong>Note</strong>: The <code>:binding_id</code> of a service binding is provided by the Cloud Controller.
+<code>:instance_id</code> is the ID of a previously-provisioned service instance; <code>:binding_id</code>
+will be used for future unbind requests, so the broker must use it to correlate
+the resource it creates.</p>
+
+##### Body #####
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Request Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>service_id*</td>
+  <td>string</td>
+  <td>ID of the service from the catalog.</td>
+</tr>
+<tr>
+  <td>plan_id*</td>
+  <td>string</td>
+  <td>ID of the plan from the catalog.</td>
+</tr>
+<tr>
+  <td>app_guid</td>
+  <td>string</td>
+  <td>GUID of the application that you want to bind your service to. Will be included when users bind applications to service instances.</td>
+</tr>
+<tr>
+  <td>bind_resource</td>
+  <td>JSON object</td>
+  <td>A JSON object that contains the required fields of the resource being bound. Currently only <code>app_guid</code> for application bindings and <code>route</code> for route bindings are supported.</td>
+</tr>
+<tr>
+  <td>parameters</td>
+  <td>JSON object</td>
+  <td>Cloud Foundry API clients can provide a JSON object of configuration parameters with their request and this value will be passed through to the service broker. Brokers are responsible for validation.</td>
+</tr>
+</tbody>
+</table>
+
+\* Fields with an asterisk are required.
+
+<pre class="terminal">
+{
+  "plan_id":      "plan-guid-here",
+  "service_id":   "service-guid-here",
+  "app_guid":     "app-guid-here",
+  "bind_resource":     {
+    "app_guid": "app-guid-here"
+  },
+  "parameters":        {
+    "parameter1-name-here": 1,
+    "parameter2-name-here": "parameter2-value-here"
+  }
+}
+</pre>
+
+<pre class="terminal">
+{
+  "plan_id":      "plan-guid-here",
+  "service_id":   "service-guid-here",
+  "bind_resource":     {
+    "route": "route-url-here"
+  },
+  "parameters":        {
+    "parameter1-name-here": 1,
+    "parameter2-name-here": "parameter2-value-here"
+  }
+}
+</pre>
+
+##### cURL #####
+<pre class="terminal">
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id -d '{
+  "plan_id":      "plan-guid-here",
+  "service_id":   "service-guid-here",
+  "app_guid":     "app-guid-here",
+  "bind_resource":     {
+    "app_guid": "app-guid-here"
+  },
+  "parameters":        {
+    "parameter1-name-here": 1,
+    "parameter2-name-here": "parameter2-value-here"
+  }
+}' -X PUT
+</pre>
+
+<pre class="terminal">
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id -d '{
+  "plan_id":      "plan-guid-here",
+  "service_id":   "service-guid-here",
+  "bind_resource":     {
+    "route": "route-url-here"
+  },
+  "parameters":        {
+    "parameter1-name-here": 1,
+    "parameter2-name-here": "parameter2-value-here"
+  }
+}' -X PUT
+</pre>
+
+In this case, `instance_id` refers to the id of an existing service instance in a previous provisioning, while `binding_id` is service binding id generated by Cloud Controller.
+
+### Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status Code</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>201 Created</td>
+  <td>Binding has been created. The expected response body is below.</td>
+</tr>
+<tr>
+  <td>200 OK</td>
+  <td>
+    May be returned if the binding already exists and the requested parameters are identical to the existing binding.
+    The expected response body is below.
+  </td>
+</tr>
+<tr>
+  <td>409 Conflict</td>
+  <td>Should be returned if the requested binding already exists. The expected response body is <code>{}</code>, though the description field can be used to return a user-facing error message, as described in <a href="#broker-errors">Broker Errors</a>.</td>
+</tr>
+<tr>
+  <td>422 Unprocessable Entity</td>
+  <td>Should be returned if the broker requires that <code>app_guid</code> be included in the request body. The expected response body is: <code>{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }</code></td>
+</tr>
+</tbody>
+</table>
+
+Responses with any other status code will be interpreted as a failure and an unbind request will be sent to the broker to prevent an orphan being created on the broker. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+
+##### Body #####
+
+All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>credentials</td>
+  <td>object</td>
+  <td>A free-form hash of credentials that the bound application can use to access the service. For more information, see <a href="binding-credentials.html">Binding Credentials</a>.</td>
+</tr>
+<tr>
+  <td>syslog_drain_url</td>
+  <td>string</td>
+  <td>A URL to which Cloud Foundry should drain logs for the bound application. <code>requires:syslog_drain</code> must be declared in the <a href="#catalog-mgmt">catalog endpoint</a> or Cloud Foundry will consider the response invalid. For details, see <a href="app-log-streaming.html">Application Log Streaming</a>.</td>
+</tr>
+<tr>
+  <td>route_service_url</td>
+  <td>string</td>
+  <td>A URL to which Cloud Foundry should proxy requests for the bound route. <code>requires:route_forwarding</code> must be declared in the <a href="#catalog-mgmt">catalog endpoint</a> or Cloud Foundry will consider the response invalid. For details, see <a href="route-services.html">Route Services</a>.</td>
+</tr>
+<tr>
+  <td>volume_mounts</td>
+  <td>array-of-objects</td>
+  <td>An array of volume mount instructions.  <code>requires:volume_mount</code> must be declared in the <a href="#catalog-mgmt">catalog endpoint</a> or Cloud Foundry will consider the response invalid.  For more information, see <a href="volume-services-v2.10.html">Volume Services</a></td>
+</tr>
+</tbody>
+</table>
+
+<pre class="terminal">
+    {
+      "credentials": {
+        "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+        "username": "mysqluser",
+        "password": "pass",
+        "host": "mysqlhost",
+        "port": 3306,
+        "database": "dbname"
+      }
+    }
+</pre>
+
+## <a id='unbinding'></a>Unbinding ##
+
+<p class="note"><strong>Note</strong>: Brokers that do not provide any bindable services do not need to implement the endpoint for unbind requests.</p>
+
+When a broker receives an unbind request from Cloud Controller, it should
+delete any resources it created in bind.
+Usually this means that an application immediately cannot access the resource.
+
+### Request ###
+
+##### Route #####
+`DELETE /v2/service_instances/:instance_id/service_bindings/:binding_id`
+
+The `:binding_id` in the URL is the identifier of a previously created binding (the same `:binding_id` passed in the bind request). The request has no body, because DELETE requests generally do not have bodies.
+
+##### Parameters #####
+
+The request provides these query string parameters as useful hints for brokers.
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Query-String Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>service_id*</td>
+  <td>string</td>
+  <td>ID of the service from the catalog.</td>
+</tr>
+<tr>
+  <td>plan_id*</td>
+  <td>string</td>
+  <td>ID of the plan from the catalog.</td>
+</tr>
+</tbody>
+</table>
+
+\* Query parameters with an asterisk are required.
+
+##### cURL #####
+<pre class="terminal">
+$ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/
+  service_bindings/:binding_id?service_id=service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.10"
+</pre>
+
+### Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status Code</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>200 OK</td>
+  <td>Binding was deleted. The expected response body is <code>{}</code>.</td>
+</tr>
+<tr>
+  <td>410 Gone</td>
+  <td>Should be returned if the binding does not exist. The expected response body is <code>{}</code>.</td>
+</tr>
+</tbody>
+</table>
+
+Responses with any other status code will be interpreted as a failure and the binding will remain in the Cloud Controller database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+
+##### Body #####
+
+All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For a success response, the expected response body is `{}`.
+
+## <a id='deprovisioning'></a>Deprovisioning ##
+
+When a broker receives a deprovision request from Cloud Controller, it should
+delete any resources it created during the provision.
+Usually this means that all resources are immediately reclaimed for future
+provisions.
+
+### Request ###
+
+##### Route #####
+`DELETE /v2/service_instances/:instance_id`
+
+The `:instance_id` in the URL is the identifier of a previously provisioned instance (the same
+`:instance_id` passed in the provision request).  The request has no body, because DELETE
+requests generally do not have bodies.
+
+##### Parameters #####
+
+The request provides these query string parameters as useful hints for brokers.
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Query-String Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>service_id*</td>
+  <td>string</td>
+  <td>ID of the service from the catalog.</td>
+</tr>
+<tr>
+  <td>plan_id*</td>
+  <td>string</td>
+  <td>ID of the plan from the catalog.</td>
+</tr>
+<tr>
+  <td>accepts_incomplete</td>
+  <td>boolean</td>
+  <td>A value of true indicates that both the Cloud Controller and the requesting client support asynchronous deprovisioning. If this parameter is not included in the request, and the broker can only deprovision an instance of the requested plan asynchronously, the broker should reject the request with a 422 as described below.</td>
+</tr>
+</tbody>
+</table>
+
+\* Query parameters with an asterisk are required.
+
+##### cURL #####
+<pre class="terminal">
+$ curl 'http://username:password@broker-url/v2/service_instances/:instance_id?service_id=
+    service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.10"
+</pre>
+
+### Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status Code</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>200 OK</td>
+  <td>Service instance was deleted. The expected response body is <code>{}</code>.</td>
+</tr>
+<tr>
+  <td>202 Accepted</td>
+  <td>Service instance deletion is in progress. This triggers Cloud Controller to poll the <a href="#polling">Service Instance Last Operation Endpoint</a> for operation status.</td>
+</tr>
+<tr>
+  <td>410 Gone</td>
+  <td>Should be returned if the service instance does not exist. The expected response body is <code>{}</code>.</td>
+</tr>
+<tr>
+  <td>422 Unprocessable Entity</td>
+  <td>Should be returned if the broker only supports asynchronous deprovisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.</td>
+</tr>
+</tbody>
+</table>
+
+Responses with any other status code will be interpreted as a failure and the service instance will remain in the Cloud Controller database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+
+##### Body #####
+
+All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>operation</td>
+  <td>string</td>
+  <td>For async responses, service brokers can return operation state as a string. This field will be provided back to the service broker on `last_operation` requests as a URL encoded query param.</a>.</td>
+</tr>
+</tboby>
+</table>
+\* Fields with an asterisk are required.
+<pre class="terminal">
+{
+ "operation": "task_10"
+}
+</pre>
+
+## <a id='broker-errors'></a>Broker Errors ##
+
+### Response ###
+
+Broker failures beyond the scope of the well-defined HTTP response codes listed
+above (like 410 on delete) should return an appropriate HTTP response code
+(chosen to accurately reflect the nature of the failure) and a body containing a valid JSON Object (not an array).
+
+##### Body #####
+
+All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For error responses, the following fields are valid. Others will be ignored. If an empty JSON object is returned in the body `{}`, a generic message containing the HTTP response code returned by the broker will be displayed to the requestor.
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>description</td>
+  <td>string</td>
+  <td>An error message explaining why the request failed. This message will be displayed to the user who initiated the request.
+</td>
+</tr>
+</tbody>
+</table>
+
+<pre class="terminal">
+{
+  "description": "Something went wrong. Please contact support at http://support.example.com."
+}
+</pre>
+
+## <a id='orphans'></a>Orphans ##
+
+The Cloud Controller is the source of truth for service instances and bindings. Service brokers are expected to have successfully provisioned all the instances and bindings Cloud Controller knows about, and none that it doesn't.
+
+Orphans can result if the broker does not return a response before a request from Cloud Controller times out (typically 60 seconds). For example, if a broker does not return a response to a provision request before Cloud Controller times out, the broker might eventually succeed in provisioning an instance after Cloud Controller considers the request a failure. This results in an orphan instance on the service side.
+
+To mitigate orphan instances and bindings, Cloud Controller will attempt to delete resources it cannot be sure were successfully created, and will keep trying to delete them until the broker responds with a success.
+
+More specifically, when a provision or bind request to the broker fails, Cloud Controller will immediately send a corresponding delete or unbind request. If the delete or unbind request fails, Cloud Controller will retry the delete or unbind request ten times with an exponental backoff schedule (over a period of 34 hours).
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Status code</th>
+  <th>Result</th>
+  <th>Orphan mitigation</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>200</td>
+  <td>Success</td>
+  <td></td>
+</tr>
+<tr>
+  <td>200 with malformed response</td>
+  <td>Failure</td>
+  <td></td>
+</tr>
+<tr>
+  <td>201</td>
+  <td>Success</td>
+  <td></td>
+</tr>
+<tr>
+  <td>201 with malformed response</td>
+  <td>Failure</td>
+  <td>Yes</td>
+</tr>
+<tr>
+  <td>All other 2xx</td>
+  <td>Failure</td>
+  <td>Yes</td>
+</tr>
+<tr>
+  <td>408</td>
+  <td>Failure due to timeout</td>
+  <td>Yes</td>
+</tr>
+<tr>
+  <td>All other 4xx</td>
+  <td>Broker rejects request</td>
+  <td></td>
+</tr>
+<tr>
+  <td>5xx</td>
+  <td>Broker error</td>
+  <td>Yes</td>
+</tr>
+<tr>
+  <td>Timeout</td>
+  <td>Failure</td>
+  <td>Yes</td>
+</tr>
+</tbody>
+</table>
+
+If the Cloud Controller encounters an internal error provisioning an instance or binding (for example, saving to the database fails), then the Cloud Controller will send a single delete or unbind request to the broker but will not retry.
+
+This orphan mitigation behavior was introduced in cf-release v196.

--- a/api.html.md.erb
+++ b/api.html.md.erb
@@ -1,1 +1,1 @@
-api-v2.9.html.md.erb
+api-v2.10.html.md.erb

--- a/volume-services-v2.10.html.md.erb
+++ b/volume-services-v2.10.html.md.erb
@@ -1,0 +1,117 @@
+---
+title: Volume Services (Experimental)
+owner: Core Services
+---
+
+<strong><%= modified_date %></strong>
+
+## <a id='introduction'></a>Introduction ##
+
+Cloud Foundry application developers may want their applications to mount one or more volumes in order to write to a reliable, non-ephemeral file system. By integrating with service brokers and the Cloud Foundry runtime, providers can offer these services to developers through an automated, self-service, and on-demand user experience.
+
+<p class="note"><strong>Note</strong>: This feature is experimental.</p>
+
+## <a id='schema'></a>Schema ##
+
+### Service Broker Bind Response ###
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>volume_mounts*</td>
+  <td>volume_mount[]</td>
+  <td>An array of <i>volume_mount</i> JSON objects</td>
+</tr>
+</tbody>
+</table>
+
+### volume_mount ###
+A volume_mount represents a remote storage device to be attached and mounted into the app container filesystem via a Volume Driver.
+<table border="1" class="nice">
+ <thead>
+ <tr>
+   <th>Field</th>
+   <th>Type</th>
+   <th>Description</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+   <td>driver</td>
+   <td>string</td>
+   <td>Name of the volume driver plugin which manages the device</td>
+ </tr>
+ <tr>
+   <td>container_dir</td>
+   <td>string</td>
+   <td>The directory to mount inside the application container</td>
+ </tr>
+ <tr>
+   <td>mode</td>
+   <td>string</td>
+   <td><tt>"r"</tt> to mount the volume read-only, or <tt>"rw"</tt> to mount it read-write</td>
+ </tr>
+ <tr>
+   <td>device_type</td>
+   <td>string</td>
+   <td>A string specifying the type of device to mount. Currently only <tt>"shared"</tt> devices are supported.</td>
+ </tr>
+ <tr>
+   <td>device</td>
+   <td>device-object</td>
+   <td>Device object containing device_type specific details. Currently only <tt>shared_device</tt> devices are supported.</td>
+ </tr>
+ </tbody>
+ </table>
+
+### shared_device ###
+A shared device are a subtype of a device. It represents a distributed file system which can be mounted on all app instances simultaneously.
+<table border="1" class="nice">
+ <thead>
+ <tr>
+   <th>Field</th>
+   <th>Type</th>
+   <th>Description</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+   <td>volume_id</td>
+   <td>string</td>
+   <td>ID of the shared volume to mount on every app instance.</td>
+ </tr>
+ <tr>
+   <td>mount_config</td>
+   <td>object</td>
+   <td>Configuration object to be passed to the driver when the volume is mounted. (optional)</td>
+ </tr>
+ </tbody>
+ </table>
+
+### Example ###
+<pre class="terminal">
+{
+  ...
+  "volume_mounts": [
+    {
+      "driver": "cephdriver",
+      "container_dir": "/data/images",
+      "mode": "r",
+      "device_type": "shared",
+      "device": {
+        "volume_id": "bc2c1eab-05b9-482d-b0cf-750ee07de311",
+        "mount_config": {
+          "key": "value"
+        }
+      }
+    }
+  ]
+}
+</pre>

--- a/volume-services.html.md.erb
+++ b/volume-services.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Volume Services (Experimental)
+title: Volume Services (Experimental/Obsolete)
 owner: Core Services
 ---
 
@@ -10,6 +10,7 @@ owner: Core Services
 Cloud Foundry application developers may want their applications to mount one or more volumes in order to write to a reliable, non-ephemeral file system. By integrating with service brokers and the Cloud Foundry runtime, providers can offer these services to developers through an automated, self-service, and on-demand user experience.
 
 <p class="note"><strong>Note</strong>: This feature is experimental.</p>
+<p class="note"><strong>Note</strong>: The v2.9 version of this experimental feature is <strong>no longer supported</strong> as of Cloud Foundry Release 240.  If you are using a newer Cloud Foundry version and your service broker returns volume mounts, you must update your service broker to use the new <a href="volume-services-v2.10.html">service broker v2.10 format for volume mounts</a>.</p>
 
 ## <a id='schema'></a>Schema ##
 


### PR DESCRIPTION
-Add new volume-services 2.10 page
-Note in the old volume-services page that the old API is obsolete
-create a new API 2.10 page, point the main version at it, and update the versions table
[#119780891](https://www.pivotaltracker.com/story/show/119780891)

Please see comments on main PR in cloud_controller_ng:
https://github.com/cloudfoundry/cloud_controller_ng/pull/660