### PR TITLE
remove link to devguide from service author index

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -22,5 +22,4 @@ To develop Managed Services for Cloud Foundry, you'll need a Cloud Foundry insta
 * <a href="binding-credentials.html" class="subnav">Binding Credentials</a>
 * <a href="app-log-streaming.html" class="subnav">Application Log Streaming</a>
 * <a href="route-services.html" class="subnav">Route Services</a>
-* <a href="../devguide/services/route-binding.html" class="subnav">Manage Application Requests with Route Services</a>
 * <a href="supporting-multiple-cf-instances.html" class="subnav">Supporting Multiple Cloud Foundry Instances</a>

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -23,3 +23,4 @@ To develop Managed Services for Cloud Foundry, you'll need a Cloud Foundry insta
 * <a href="app-log-streaming.html" class="subnav">Application Log Streaming</a>
 * <a href="route-services.html" class="subnav">Route Services</a>
 * <a href="supporting-multiple-cf-instances.html" class="subnav">Supporting Multiple Cloud Foundry Instances</a>
+* <a href="volume-services-v2.10.html" class="subnav">Volume Services (Experimental)</a>


### PR DESCRIPTION
this link can already be found at the top of the route services topic: http://docs.cloudfoundry.org/services/route-services.html

I don't think it should be in the index