### PR TITLE
remove experimental label from volume services

### DIFF
--- a/api.html.md.erb
+++ b/api.html.md.erb
@@ -24,7 +24,7 @@ that do not understand them.
 
 ### <a id='api-changes-since-v2-9'></a>Changes Since v2.9 ###
 
-* Backward incompatible changes to experimental `volume_mounts` field in service bind response.
+* Backward incompatible changes to `volume_mounts` field in service bind response from experimental 2.9 format to final format.
 
 ## <a id='dependencies'></a>Dependencies ##
 
@@ -899,7 +899,7 @@ In response to a bind request for an application (`app_id` included), a broker m
 
 If a broker has declared `"requires":["route_forwarding"]` for a service in the Catalog endpoint, Cloud Foundry will permit a user to bind a service to a route. When bound to a route, the route itself will be sent with the bind request. A route is an address used by clients to reach apps mapped to the route. In response a broker may return a `route_service_url` which Cloud Foundry will use to proxy any request for the route to the service instance at URL specified by `route_service_url`. A broker may declare `"requires":["route_forwarding"]` but not return `route_service_url`; this enables a broker to dynamically configure a network component already in the request path for the route, requiring no change in the Cloud Foundry router. For more information, see [Route Services](route-services.html).
 
-#### <a id='binding-volume-services'></a>Volume Services (Experimental)####
+#### <a id='binding-volume-services'></a>Volume Services ####
 
 If a broker has declared `"requires":["volume_mount"]` for a service in the Catalog endpoint, Cloud Foundry will permit a user to bind one or more volumes to an application.  In response to a bind request a volume service broker should return a set of `volume_mount` instructions that Cloud Foundry will ensure are mounted into the application's containers.  For more information, see [Volume Services](volume-services-v2.10.html)
 

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -23,4 +23,4 @@ To develop Managed Services for Cloud Foundry, you'll need a Cloud Foundry insta
 * <a href="app-log-streaming.html" class="subnav">Application Log Streaming</a>
 * <a href="route-services.html" class="subnav">Route Services</a>
 * <a href="supporting-multiple-cf-instances.html" class="subnav">Supporting Multiple Cloud Foundry Instances</a>
-* <a href="volume-services-v2.10.html" class="subnav">Volume Services (Experimental)</a>
+* <a href="volume-services-v2.10.html" class="subnav">Volume Services</a>

--- a/v2-api-changelog.html.md.erb
+++ b/v2-api-changelog.html.md.erb
@@ -9,7 +9,7 @@ owner: Services API
 
 Bump API version to 2.10
 
-Service bind responses now include an experimental field called `volume_mounts`. These changes are backwards incompatible.
+Service bind responses now include an optional field called `volume_mounts`.
 
 ## 2016-06-14 ##
 

--- a/volume-services-v2.10.html.md.erb
+++ b/volume-services-v2.10.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Volume Services (Experimental)
+title: Volume Services
 owner: Core Services
 ---
 
@@ -8,8 +8,6 @@ owner: Core Services
 ## <a id='introduction'></a>Introduction ##
 
 Cloud Foundry application developers may want their applications to mount one or more volumes in order to write to a reliable, non-ephemeral file system. By integrating with service brokers and the Cloud Foundry runtime, providers can offer these services to developers through an automated, self-service, and on-demand user experience.
-
-<p class="note"><strong>Note</strong>: This feature is experimental.</p>
 
 ## <a id='schema'></a>Schema ##
 


### PR DESCRIPTION
These changes remove the experimental label from the services portion of the documentation. We have submitted a separate PR to docs-book-cloudfoundry that adds volume services to the index and the nav bar.

[finishes #130244039]

Signed-off-by: Jeff Pak <jeffrey.pak@emc.com>