### PR TITLE
Update title of service broker API

### DIFF
--- a/api.html.md.erb
+++ b/api.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Service Broker API v2.11
+title: Open Service Broker API
 owner: Services API
 ---
 


### PR DESCRIPTION
[#145423915]

Content for the Service Broker API documentation is now provided by the [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker) working group. 

This change is necessary to reflect the platform agnostic API that CF now adopts for service brokers. 

The version of the open service broker api in use by Cloud Foundry is specified in the documentation contents. 
