### PR TITLE
Add "read" permission to service instance permissions docs

### DIFF
--- a/dashboard-sso.html.md.erb
+++ b/dashboard-sso.html.md.erb
@@ -117,11 +117,16 @@ Response:
 
 ```
 {
-  "manage": true
+  "manage": true,
+  "read": true
 }
 ```
 
-The response will indicate to the service whether this user is allowed to manage the given instance. A `true` value for the `manage` key indicates sufficient permissions; `false` would indicate insufficient permissions.  Since administrators may change the permissions of users, the service should check this endpoint whenever a user uses the SSO flow to access the service's UI.
+The response includes the following fields which indicate the various user permissions for the given service instance:
+- `manage` -- a `true` value indicates that the user has sufficient permissions to make changes to and update the service instance; `false` indicates insufficient permissions.
+- `read` -- a `true` value indicates that the user has permission to access read-only diagnostic and monitoring information for the given service instance (e.g. permission to view a read-only dashboard); `false` indicates insufficient permissions.
+
+Since administrators may change the permissions of users at any time, the service should check this endpoint whenever a user uses the SSO flow to access the service's UI.
 
 ### <a id="on-scopes"></a> On Scopes
 


### PR DESCRIPTION
Hey Docs team,

We recently updated the `/v2/service_instances/:guid/permissions` endpoint to include a "read" attribute.  It's basically there to let service operators grant `read-only` access to some users (such as auditors) without giving them full "manage" access.  See [this story](https://www.pivotaltracker.com/n/projects/966314/stories/141794109) for more context.

Let me know if you have any questions!

**Note:** Please check with our PM @zrob before publishing this.

CAPI Story: https://www.pivotaltracker.com/story/show/146049555

> Commit message:
> ```
> - The /v2/service_instances/:guid/permissions CC endpoint now includes
>   a "read" attribute that indicates whether a user should be able to
>   view read-only diagnostic / monitoring information for a given
>   service instance
> 
> [#146049555]
> ```
> 

Thanks!
@tcdowney