### PR TITLE
Corrects outdated guidance on shared services bindings

### DIFF
--- a/enable-sharing.html.md.erb
+++ b/enable-sharing.html.md.erb
@@ -41,11 +41,7 @@ When a service instance is created in one space and shared into another, develop
 
 You may want to have the service broker return credentials with different permissions depending on which space an app is bound from. For example, a messaging service may permit writes from the originating space and only reads from any spaces that the service is shared into.
 
-To differentiate between the spaces, implement the following:
-
-1. During the provision request, the broker stores the org and space GUIDs of the service instance by inspecting the `context` object.
-
-1. On a subsequent bind request, the broker compares the new `context` object's org and space GUIDs against the stored provision request information to determine if the bind request originated from a space the service instance is shared into.
+To determine whether the space of the app is the same as the originating space of the service instance, the service broker can compare the `context.space_guid` and `bind_resource.space_guid` fields in the binding request. The `context.space_guid` field represents the space where the service instance was created, and `bind_resource.space_guid` represents the space of the app involved in the binding.
 
 ## <a id="security"></a> Security Considerations
 


### PR DESCRIPTION
This PR updates/corrects docs related to binding a shared service instance.

As of this PR: https://github.com/cloudfoundry/cloud_controller_ng/pull/1069, it's now a lot simpler for service brokers to determine whether a binding request comes from the originating space of the service instance or the space that has access to the instance via sharing. Additionally, the existing documentation is actually incorrect because the `context` object in a bind request refers to the space of the service instance, not the space of the bind.

Thanks,
Services API team (Luis & @jenspinney)