### PR TITLE
Update index.html.md.erb

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -8,7 +8,7 @@ owner: Core Services
 
 The documentation in this section is intended for developers and operators interested in creating Managed Services for Cloud Foundry. Managed Services are defined as having been integrated with Cloud Foundry via APIs, and enable end users to provision reserved resources and credentials on demand. For documentation targeted at end users, such as how to provision services and integrate them with applications, see [Services Overview](../devguide/services/index.html).
 
-To develop Managed Services for Cloud Foundry, you'll need a Cloud Foundry instance to test your service broker with as you are developing it. You must have admin access to your CF instance to manage service brokers and the services marketplace catalog. For local development, we recommend using [BOSH Lite](https://github.com/cloudfoundry/bosh-lite) to deploy your own local instance of Cloud Foundry.
+To develop Managed Services for Cloud Foundry, you'll need a Cloud Foundry instance to test your service broker with as you are developing it. You must have admin access to your CF instance to manage service brokers and the services marketplace catalog. For local development, we recommend using the [BOSH guide](https://bosh.io/docs/quick-start/) to deploy your own local instance of Cloud Foundry using VirtualBox.
 
 ## Table of Contents
 


### PR DESCRIPTION


Changed the recommendations on installing BOSH locally since the BOSH Lite repository is deprecated. It is no longer maintained, and it is not recommended for continued use.