### PR TITLE
Update docs to reflect multi service registration

### DIFF
--- a/access-control.html.md.erb
+++ b/access-control.html.md.erb
@@ -97,6 +97,8 @@ broker: p-mysql
    p-mysql   100mb-dev   all
 </pre>
 
+<p class="note"><strong>Note</strong>: When there are two or more services with the same name provided by multiple brokers, you must specify the broker using <code>-b BROKER</code> flag to the <code>cf enable-service-access</code> command.</p>
+
 
 ## <a id='disable-access'></a>Disable Access to Service Plans ###
 
@@ -127,6 +129,8 @@ The `-p` and `-o` flags to `cf disable-service-access` let the admin deny access
 - `-p PLAN -o ORG` prevents users in one org from accessing one plan
 
 Run `cf help disable-service-access` to review these options from the command line.
+
+<p class="note"><strong>Note</strong>: When there are two or more services with the same name provided by multiple brokers, you must specify the broker using <code>-b BROKER</code> flag to the <code>cf disable-service-access</code> command.</p>
 
 ### Limitations ####
 

--- a/managing-service-brokers.html.md.erb
+++ b/managing-service-brokers.html.md.erb
@@ -63,8 +63,12 @@ many services and plans.
 The following constraints should be kept in mind:
 
 - It is not possible to have multiple brokers with the same name
-- It is not possible to have multiple brokers with the same base URL
 - The service ID and plan IDs of each service advertised by the broker must be unique across Cloud Foundry. GUIDs are recommended for these fields.
+
+<div class="note">
+Since Cloud Controller API (CC API) version number <code>2.125.0</code> it is possible to add multiple brokers with the same URL
+(as long as they have different names). Prior to that it wasn't possible.
+</div>
 
 See [Possible Errors](#possible-errors) below for error messages and what do to
 when you see them.
@@ -73,7 +77,7 @@ when you see them.
 
 <pre class="terminal">
 $ cf service-brokers
-Getting service brokers as admin...Cloud Controller
+Getting service brokers as admin...
 OK
 
 Name            URL
@@ -159,6 +163,8 @@ OK
 </pre>
 
 `purge-service-instance` requires cf-release v218 and cf CLI 6.14.0.
+
+<p class="note"><strong>Note</strong>: When there are two or more services with the same name provided by multiple brokers, you must specify the broker using <code>-b BROKER</code> flag to the <code>cf purge-service-offering</code> command.</p>
 
 ## <a id='catalog-validation'></a> Catalog Validation Behaviors ##
 


### PR DESCRIPTION
We recently finished the multi-service registration feature, that adds a -b flag to service related commands, to filter the service by broker name when there are multiple services with the same name.
This PR updates documentation for those commands.

More info [here](https://www.pivotaltracker.com/story/show/158422603).