### PR TITLE
Fix improper wording in access-control docs

### DIFF
--- a/access-control.html.md.erb
+++ b/access-control.html.md.erb
@@ -97,7 +97,7 @@ broker: p-mysql
    p-mysql   100mb-dev   all
 </pre>
 
-<p class="note"><strong>Note</strong>: When multiple brokers provide two or more service instances with the same name, you must specify the broker by including the <code>-b BROKER</code> flag in the <code>cf enable-service-access</code> command.</p>
+<p class="note"><strong>Note</strong>: When multiple brokers provide two or more services with the same name, you must specify the broker by including the <code>-b BROKER</code> flag in the <code>cf enable-service-access</code> command.</p>
 
 
 ## <a id='disable-access'></a>Disable Access to Service Plans ###
@@ -130,7 +130,7 @@ The `-p` and `-o` flags to `cf disable-service-access` let the admin deny access
 
 Run `cf help disable-service-access` to review these options from the command line.
 
-<p class="note"><strong>Note</strong>: When multiple brokers provide two or more service instances with the same name, you must specify the broker by including the <code>-b BROKER</code> flag in the <code>cf disable-service-access</code> command.</p>
+<p class="note"><strong>Note</strong>: When multiple brokers provide two or more services with the same name, you must specify the broker by including the <code>-b BROKER</code> flag in the <code>cf disable-service-access</code> command.</p>
 
 ### Limitations ####
 


### PR DESCRIPTION
The commands `enable-service-access` and `disable-service-access` have notes that use the term `service instance` which is not correct in the context since the commands work with `services` not `service instances`.
More information on the [tracker story](https://www.pivotaltracker.com/story/show/165760197)

Best Regards,
Niki
On behalf of SAPI Team