### PR TITLE
Multi service registration relaxes id uniqueness reqs

### DIFF
--- a/managing-service-brokers.html.md.erb
+++ b/managing-service-brokers.html.md.erb
@@ -63,8 +63,11 @@ many services and plans.
 The following constraints should be kept in mind:
 
 - It is not possible to have multiple brokers with the same name
-- The service ID and plan IDs of each service advertised by the broker must be unique across Cloud Foundry. GUIDs are recommended for these fields.
+- Prior to Cloud Foundry API (CAPI) v1.71, the service ID and plan IDs of each service advertised by the broker must be unique across Cloud Foundry.
+- With Cloud Foundry API (CAPI) v1.71 or later, the service ID and plan IDs of each service advertised by the broker must be unique only within the broker and can overlap ids defined in other brokers
+- GUIDs are recommended for the service ID and plan IDs of each service.
 
+    
 <div class="note"><strong>Note</strong>: 
 If your deployment uses Cloud Foundry API (CAPI) v1.71 or later, you can add multiple brokers with the same URL. In this case, the brokers must have different names. CAPI v1.70 and earlier do not support this feature.
 </div>


### PR DESCRIPTION
Refine service catalog id uniqueness requirements following  [multi service registration](    https://docs.google.com/document/d/1_OBnFCsL3ru43PEXocsCc3EuGaM0YLHjr0iAoXnakt4/edit#).

https://www.pivotaltracker.com/n/projects/2105761/stories/158422603 planned to update the sentence below, but it seems it got missed in commit https://github.com/waterlink/docs-services/commit/855e106bc00c98d90c14812e3ba1dd9b37de8cb0

> The service ID and plan IDs of each service advertised by the broker must be unique across Cloud Foundry. GUIDs are recommended for these fields.

/CC @waterlink @georgi-lozev @AartiKriplani