### PR TITLE
Replace references to v2 service permissions endpoint with v3, misc c…

### DIFF
--- a/dashboard-sso.html.md.erb
+++ b/dashboard-sso.html.md.erb
@@ -100,8 +100,8 @@ $ curl api.example.com/info
 "allow_debug":true}
 ```
 
-<p class='note'>To enable service dashboards to support SSO for service instances created from different <%= vars.app_runtime_abbr %> instances, the /v2/info url is sent to service brokers in the <code>X-Api-Info-Location</code> header of every API call. A service dashboard should be able to discover this URL from the broker, and enabling the dashboard to contact the appropriate UAA for a particular service instance.</p>
 
+<p class='note'>To enable service dashboards to support SSO for service instances created from different <%= vars.app_runtime_abbr %> instances, the /v2/info url is sent to service brokers in the <code>X-Api-Info-Location</code> header of every API call. A service dashboard should be able to discover this URL from the broker, which would enable the dashboard to contact the appropriate UAA for a particular service instance. Note that although the Cloud Foundry API (CAPI) V2 is now deprecated, the Cloud Controller will still communicate its /v2/info URL via this header. /v2/info is the sole CAPI V2 endpoint that will continue to be served even where a Cloud Controller has been configured, via the CAPI bosh release, to disable the V2 API</p>
 A service dashboard should implement the OAuth Authorization Code Grant type ([UAA documentation](https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst#authorization-code-grant), [RFC documentation](http://tools.ietf.org/html/rfc6749#section-4.1)).
 
 1. When a user visits the service dashboard at the value of `dashboard_url`, the dashboard should redirect the user's browser to the Authorization Endpoint and include its `client_id`, a `redirect_uri` (callback URL with domain matching the value of `dashboard_client.redirect_uri`), and list of requested scopes.
@@ -125,30 +125,28 @@ A service dashboard should implement the OAuth Authorization Code Grant type ([U
 
 UAA is responsible for authenticating a user and providing the service with an access token with the requested permissions. However, after the user has been logged in, it is the responsibility of the service dashboard to verify that the user making the request to manage an instance currently has access to that service instance.
 
-The service can accomplish this with a GET to the `/v2/service_instances/:guid/permissions` endpoint on the Cloud Controller. The request must include a token for an authenticated user and the service instance guid. The token is the same one obtained from the UAA in response to a request to the Token Endpoint, described above.
+The service can accomplish this with a GET to the `/v3/service_instances/:guid/permissions` endpoint on the Cloud Controller. The request must include a token for an authenticated user and the service instance guid. The token is the same one obtained from the UAA in response to a request to the Token Endpoint, described above.
 .
 
-Example Request:
+- Example Request:
 
-```
-curl -H 'Content-Type: application/json' \
+  ```
+  curl -H 'Content-Type: application/json' \
        -H 'Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoid' \
-       http://api.cloudfoundry.com/v2/service_instances/44b26033-1f54-4087-b7bc-da9652c2a539/permissions
+       http://api.cloudfoundry.com/v3/service_instances/44b26033-1f54-4087-b7bc-da9652c2a539/permissions
 
-```
+  ```
+- Response:
 
-Response:
-
-```
-{
-  "manage": true,
-  "read": true
-}
-```
-
-The response includes the following fields which indicate the various user permissions for the given service instance:
-- `manage` -- a `true` value indicates that the user has sufficient permissions to make changes to and update the service instance; `false` indicates insufficient permissions.
-- `read` -- a `true` value indicates that the user has permission to access read-only diagnostic and monitoring information for the given service instance (e.g. permission to view a read-only dashboard); `false` indicates insufficient permissions.
+    ```
+    {
+      "manage": true,
+      "read": true
+    }
+    ```
+    The response includes the following fields which indicate the various user permissions for the given service instance:
+    - `manage`: if `true`, the user has sufficient permissions to make changes to and update the service instance; `false` indicates insufficient permissions.
+    - `read`: if `true`, the user has permission to access read-only diagnostic and monitoring information for the given service instance (e.g. permission to view a read-only dashboard); `false` indicates insufficient permissions.
 
 Since administrators may change the permissions of users at any time, the service should check this endpoint whenever a user uses the SSO flow to access the service's UI.
 


### PR DESCRIPTION
This documents the change introduced in cloudfoundry/cloud_controller_ng#2946, which creates a v3 endpoint equivalent to `/v2/service_instances/:guid/permissions`

Also clarifies the fact that `/v2/info` will continue to be advertised (and served) by the Cloud Controller even when the v2 API is disabled via the CAPI release.